### PR TITLE
Bug Fixes + Style Improvements

### DIFF
--- a/SSASwiftReachability/SSASwiftReachability.swift
+++ b/SSASwiftReachability/SSASwiftReachability.swift
@@ -9,8 +9,8 @@
 import SystemConfiguration
 import Foundation
 
-let reachabilityDidChangeNotification = "ReachabilityChangedNotification"
-let reachabilityNotificationStatusItem = "ReachabilityNotificationStatusItem"
+let SSAReachabilityDidChangeNotification = "ReachabilityChangedNotification"
+let SSAReachabilityNotificationStatusItem = "ReachabilityNotificationStatusItem"
 
 func callback(target: SCNetworkReachability, flags: SCNetworkReachabilityFlags, info: UnsafeMutablePointer<Void>) {
     let reachability = Unmanaged<SSASwiftReachability>.fromOpaque(COpaquePointer(info)).takeUnretainedValue()
@@ -24,7 +24,7 @@ public class SSASwiftReachability {
     
     typealias ReachabilityStatusChangedClosure = (ReachabilityStatus) -> ()
     
-    // MARK: Public Enums
+// MARK: Public Enums
     
     enum ReachabilityStatus: Int {
         case Unknown = -1
@@ -62,7 +62,7 @@ public class SSASwiftReachability {
         case Advanced = 2
     }
     
-    // MARK: Public Variables
+// MARK: Public Variables
     
     var networkReachabilityStatus: ReachabilityStatus = .Unknown
     var reachabilityAssociation: ReachabilityAssociation = .ForName
@@ -72,14 +72,13 @@ public class SSASwiftReachability {
         return networkReachabilityStatus.description
     }
     
-    // MARK: Public Optional Variables
+// MARK: Public Optional Variables
     
     var reachabilityStatusChangedClosure: ReachabilityStatusChangedClosure?
     
-    // MARK: Public Class Variables
+// MARK: Public Class Variables
     
     class var zeroAdress: sockaddr_in {
-        
         var address: sockaddr_in = sockaddr_in(sin_len: __uint8_t(0), sin_family: sa_family_t(0), sin_port: in_port_t(0), sin_addr: in_addr(s_addr: 0), sin_zero: (0, 0, 0, 0, 0, 0, 0, 0))
         address.sin_len = UInt8(sizeofValue(address))
         address.sin_family = sa_family_t(AF_INET)
@@ -87,33 +86,30 @@ public class SSASwiftReachability {
         return address
     }
     
-    // MARK: Private Variables
+// MARK: Private Variables
     
     private var networkReachability: SCNetworkReachabilityRef?
     private var lastNetworkReachabilityStatus: ReachabilityStatus = .Unknown
     
-    // MARK: Singleton
+// MARK: Singleton
     
     static let sharedManager: SSASwiftReachability? = SSASwiftReachability.managerForAddress(SSASwiftReachability.zeroAdress)
     
-    
-    //MARK: Initialization
+// MARK: Initialization
     
     private init(reachabilityRef: SCNetworkReachability, reachabilityAssociation: ReachabilityAssociation) {
         self.networkReachability = reachabilityRef
         self.reachabilityAssociation = reachabilityAssociation
     }
     
-    //MARK: Public Class Functions
+// MARK: Public Class Functions
     
     class func managerForDomain(domain: String) -> SSASwiftReachability? {
         let reachabilityRef: SCNetworkReachability? = SCNetworkReachabilityCreateWithName(kCFAllocatorDefault, (domain as NSString).UTF8String)
-        
         return SSASwiftReachability(reachabilityRef: reachabilityRef!, reachabilityAssociation: .ForName)
     }
     
     class func managerForAddress(var address: sockaddr_in) -> SSASwiftReachability? {
-        
         let reachabilityRef = withUnsafePointer(&address) {
             SCNetworkReachabilityCreateWithAddress(nil, UnsafePointer($0))
         }
@@ -121,7 +117,7 @@ public class SSASwiftReachability {
         return SSASwiftReachability(reachabilityRef: reachabilityRef!, reachabilityAssociation: .ForAddress)
     }
     
-    //MARK: Public Functions
+// MARK: Public Functions
     
     func isReachable() -> Bool {
         return networkReachabilityStatus == .Reachable || networkReachabilityStatus == .ReachableViaWWAN || networkReachabilityStatus == .ReachableViaWiFi
@@ -135,117 +131,100 @@ public class SSASwiftReachability {
         return networkReachabilityStatus == .ReachableViaWiFi
     }
     
-    // MARK: Start Monitoring For Reachability Changes
+// MARK: Start Monitoring For Reachability Changes
     
     func startMonitoring() {
         stopMonitoring()
+        guard let reachability = networkReachability else { return }
+            
+        let statusClosure: ReachabilityStatusChangedClosure = { [weak self] status in
+            self?.networkReachabilityStatus = status
+        }
         
-        if let reachability = networkReachability {
+        var context = SCNetworkReachabilityContext(version: 0, info: nil, retain: nil, release: nil, copyDescription: nil)
+        context.info = UnsafeMutablePointer(Unmanaged.passUnretained(self).toOpaque())
+        
+        SCNetworkReachabilitySetCallback(reachability, callback, &context)
+        SCNetworkReachabilityScheduleWithRunLoop(reachability, CFRunLoopGetMain(), kCFRunLoopCommonModes)
+        
+        // Get Initial Reachability Status
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)) {
+            var flags: SCNetworkReachabilityFlags = SCNetworkReachabilityFlags()
+            SCNetworkReachabilityGetFlags(reachability, &flags)
+            let status: ReachabilityStatus = self.reachabilityStatus(flags)
             
-            let statusClosure: ReachabilityStatusChangedClosure = { [weak self] (status) -> () in
-                
-                if let s = self {
-                    s.networkReachabilityStatus = status
-                }
-                
+            dispatch_async(dispatch_get_main_queue()) {
+                statusClosure(status)
+                NSNotificationCenter.defaultCenter().postNotificationName(SSAReachabilityDidChangeNotification, object:self, userInfo: [SSAReachabilityNotificationStatusItem : "\(status)"])
             }
-            
-            var context = SCNetworkReachabilityContext(version: 0, info: nil, retain: nil, release: nil, copyDescription: nil)
-            context.info = UnsafeMutablePointer(Unmanaged.passUnretained(self).toOpaque())
-            
-            SCNetworkReachabilitySetCallback(reachability, callback, &context)
-            SCNetworkReachabilityScheduleWithRunLoop(reachability, CFRunLoopGetMain(), kCFRunLoopCommonModes)
-            
-            // MARK: Get Initial Reachability Status
-            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), {
-                var flags: SCNetworkReachabilityFlags = SCNetworkReachabilityFlags()
-                SCNetworkReachabilityGetFlags(reachability, &flags)
-                
-                let status: ReachabilityStatus = self.reachabilityStatus(flags)
-                
-                dispatch_async(dispatch_get_main_queue(), {
-                    
-                    statusClosure(status)
-                    
-                    NSNotificationCenter.defaultCenter().postNotificationName(reachabilityDidChangeNotification, object:self, userInfo: [reachabilityNotificationStatusItem : "\(status)"])
-                })
-                
-                
-            })
-            
         }
     }
     
-    // MARK: Stop Monitoring For Reachability Changes
+// MARK: Stop Monitoring For Reachability Changes
     
     func stopMonitoring() {
-        
-        if let reachability = networkReachability {
-            SCNetworkReachabilityUnscheduleFromRunLoop(reachability, CFRunLoopGetMain(), kCFRunLoopCommonModes);
-        }else {
-            return
-        }
+        guard let reachability = networkReachability else { return }
+        SCNetworkReachabilityUnscheduleFromRunLoop(reachability, CFRunLoopGetMain(), kCFRunLoopCommonModes);
     }
     
-    // MARK: Handle Reachability Change
+// MARK: Handle Reachability Change
     
     func reachabilityCallback(flags: SCNetworkReachabilityFlags) {
-        
         let status: ReachabilityStatus = reachabilityStatus(flags)
+        guard status != self.networkReachabilityStatus else { return }
+        
         if let closure = reachabilityStatusChangedClosure {
             closure(status)
         }
-        dispatch_async(dispatch_get_main_queue(), {
-            if !(status == self.lastNetworkReachabilityStatus) {
-                NSNotificationCenter.defaultCenter().postNotificationName(reachabilityDidChangeNotification, object:self, userInfo: [reachabilityNotificationStatusItem : "\(status)"])
-                self.lastNetworkReachabilityStatus = status
-            }
+        dispatch_async(dispatch_get_main_queue()) {
+            self.lastNetworkReachabilityStatus = self.networkReachabilityStatus
             self.networkReachabilityStatus = status
-        })
+            NSNotificationCenter.defaultCenter().postNotificationName(SSAReachabilityDidChangeNotification, object:self, userInfo: [SSAReachabilityNotificationStatusItem : "\(status)"])
+        }
     }
     
-    //MARK: Private Functions
+// MARK: Private Functions
     
     private func reachabilityStatus(flags: SCNetworkReachabilityFlags) -> ReachabilityStatus {
-        
         let isReachable: Bool = flags.contains(.Reachable)
         let isConnectionRequired: Bool = flags.contains(.ConnectionRequired)
         let canConnectAutomatically: Bool = flags.contains(.ConnectionOnDemand) || flags.contains( .ConnectionOnTraffic)
         let canConnectWithoutUserInteraction = canConnectAutomatically && !flags.contains(.InterventionRequired)
         let isNetworkReachable: Bool = (isReachable && (!isConnectionRequired || canConnectWithoutUserInteraction))
+#if os(iOS)
         let isOnWWAN: Bool = flags.contains(SCNetworkReachabilityFlags.IsWWAN)
-        
+#endif
         var status: ReachabilityStatus = .Unknown
         
         if !isNetworkReachable {
             status = .NotReachable
-        }else {
+        } else {
             switch reachabilityInformationMode {
-                
             case .Simple:
                 status = .Reachable
             case .Advanced:
+#if os(iOS)
                 if isOnWWAN {
                     #if (arch(i386) || arch(x86_64)) && os(iOS)
                         status = .ReachableViaWWAN
                     #endif
-                }else {
+                } else {
                     status = .ReachableViaWiFi
                 }
+#else
+                status = .ReachableViaWiFi
+#endif
             }
         }
         
         return status
     }
     
-    //MARK: Deinitialization
+// MARK: Deinitialization
     
     deinit {
-        
         stopMonitoring()
-        
         networkReachability = nil
-        
     }
     
 }


### PR DESCRIPTION
- Previously SSASwiftReachability would not compile on OS X as
  SCNetworkReachabilityFlags.IsWWAN is only available on iOS
- Previously the current reachability status has been changed after the
  notification was sent, thus checking the status when receiving the
  notification would give back an invalid status
- Improved code style by e.g. using Swift 2’s guard statement if
  appropriate
