### PR TITLE
Fixed .ReachableViaWWAN not working

### DIFF
--- a/SSASwiftReachability/SSASwiftReachability.swift
+++ b/SSASwiftReachability/SSASwiftReachability.swift
@@ -205,9 +205,7 @@ public class SSASwiftReachability {
             case .Advanced:
 #if os(iOS)
                 if isOnWWAN {
-                    #if (arch(i386) || arch(x86_64)) && os(iOS)
-                        status = .ReachableViaWWAN
-                    #endif
+                    status = .ReachableViaWWAN
                 } else {
                     status = .ReachableViaWiFi
                 }


### PR DESCRIPTION
The code that sets the .ReachableViaWWAN flag was guarded by a check that would only return true on the simulator and not on a device. This resulted in getting a .Unknown status when connected on a cellular connection. This commit removes the check.
